### PR TITLE
fix for duplicate key exception for InflightMessages

### DIFF
--- a/GnatMQ/Managers/MqttSessionManager.cs
+++ b/GnatMQ/Managers/MqttSessionManager.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
 Copyright (c) 2013, 2014 Paolo Patierno
 
 All rights reserved. This program and the accompanying materials
@@ -81,7 +81,7 @@ namespace uPLibrary.Networking.M2Mqtt.Managers
             session.InflightMessages = new Hashtable();
             foreach (MqttMsgContext msgContext in clientSession.InflightMessages.Values)
             {
-                session.InflightMessages.Add(msgContext.Message.MessageId, msgContext);
+                session.InflightMessages.Add(msgContext.Key, msgContext);
             }
         }
 


### PR DESCRIPTION
key to the InflightMessages HashTable should be the MsgContext.Key property, as MessageId is not unique (also depends on flow).

[Adding to / removing from InflightMessages is correct everywhere else]